### PR TITLE
Insure fragment checkbox has the consistent id

### DIFF
--- a/app/views/wheelhouse/admin/resource/_navigation_options.html.haml
+++ b/app/views/wheelhouse/admin/resource/_navigation_options.html.haml
@@ -14,6 +14,6 @@
       = form.text_field :path, :id => 'path'
 
       - if resource.respond_to?(:fragment=)
-        = form.check_box :fragment, :label => resource_class.human_attribute_name(:fragment), :class => "small"
+        = form.check_box :fragment, :id => 'page_fragment', :label => resource_class.human_attribute_name(:fragment), :class => "small"
 
   = resource_hook(:"sidebar.navigation_options")


### PR DESCRIPTION
In order for fragment javascript to work for advanced pages or other plugins, the id of the fragment checkbox needs to be set.